### PR TITLE
Add the repository owner as assignee to the newly created pull-request.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,6 +84,7 @@ runs:
           core/i18n/*.json
           plugin_info/info.json
         title: "Update translations"
+        assignees: ${{ github.repository_owner }}
         body: "Automated translations done by [Mips2648/plugins-translations workflow](https://github.com/Mips2648/plugins-translations)"
         commit-message: "Auto update translation done by Mips2648/plugins-translations workflow"
 


### PR DESCRIPTION
Hello,

that could be nice to assign the PR to the repo owner (so the PR are listed when you go there :
![image](https://github.com/user-attachments/assets/3585b1d0-a2cc-4dd5-a484-426038d6bab3)
![image](https://github.com/user-attachments/assets/0c491de9-5bc8-4e06-bd78-17b2ddaa9a00)
